### PR TITLE
Paramgen: Remove pg-messageId.sql

### DIFF
--- a/paramgen/paramgen-queries/pg-messageId.sql
+++ b/paramgen/paramgen-queries/pg-messageId.sql
@@ -1,5 +1,0 @@
-SELECT MessageId AS MessageId, 
-  FROM messageIds 
- WHERE deletionDay > :date_limit_filter AND creationDay < :date_limit_filter
- ORDER BY md5(MessageId) 
-LIMIT 50  

--- a/paramgen/scripts/paramgen.sh
+++ b/paramgen/scripts/paramgen.sh
@@ -10,5 +10,4 @@ python3 paramgen.py \
 --raw_parquet_dir "${LDBC_SNB_DATA_ROOT_DIRECTORY}/graphs/parquet/raw/" \
 --factor_tables_dir "${LDBC_SNB_FACTOR_TABLES_DIR}" \
 --time_bucket_size_in_days 1 \
---generate_short_query_parameters True \
 --threshold_values_path 'paramgen_window_values.json'


### PR DESCRIPTION
This makes the 'messageIds' factor table, which is the most expensive factor table, obsolete.

The reason this paramgen query was there to allow quick generator of message IDs for testing the short queries. While nice, this does not justify the cost of generating the massive messageIds factor table.